### PR TITLE
Allow Shift+Enter on an empty task to trigger deletion

### DIFF
--- a/app/components/single-line-textarea.js
+++ b/app/components/single-line-textarea.js
@@ -4,18 +4,20 @@ import { action } from '@ember/object';
 export default class SingleLineTextarea extends Component {
   @action
   insertNewline(value, event) {
-    if (!event.shiftKey) {
-      if (this.args['insert-newline'])
-        this.args['insert-newline'](...arguments);
+    if (!this.args['insert-newline']) return;
+
+    if (value.trim() === '' || !event.shiftKey) {
+      this.args['insert-newline'](...arguments);
     }
   }
 
   @action
-  preventDefaultOnShiftlessEnter(event) {
-    if (event.key === 'Enter') {
-      if (!event.shiftKey) {
-        event.preventDefault();
-      }
+  preventDefaultWhenSubmitting(event) {
+    if (event.key !== 'Enter') return;
+
+    let value = event.target.value.trim();
+    if (value === '' || !event.shiftKey) {
+      event.preventDefault();
     }
   }
 }

--- a/app/components/single-task.js
+++ b/app/components/single-task.js
@@ -96,13 +96,13 @@ export default class SingleTask extends Component {
       return;
     }
     let task = this.args.task;
-    let description = this.editDescription;
-    if (!isEmpty(description)) {
+    let description = this.editDescription.trim();
+    if (isEmpty(description)) {
+      await task.destroyRecord();
+    } else {
       task.description = description;
       await task.save();
       this.isEditing = false;
-    } else {
-      await task.destroyRecord();
     }
     if (this.args.editingEnd) this.args.editingEnd();
   }

--- a/app/templates/components/single-line-textarea.hbs
+++ b/app/templates/components/single-line-textarea.hbs
@@ -5,6 +5,7 @@
   @focus-out={{@focus-out}}
   @insert-newline={{this.insertNewline}}
 
-  {{on "keydown" this.preventDefaultOnShiftlessEnter}}
+  {{on "keydown" this.preventDefaultWhenSubmitting}}
+
   ...attributes
 />

--- a/app/templates/components/task-list/header.hbs
+++ b/app/templates/components/task-list/header.hbs
@@ -1,5 +1,5 @@
 <div class="task-list-header">
-  {{#if hasBlock}}
+  {{#if (has-block)}}
     {{yield @list}}
   {{else}}
     <h1>{{@list.name}}</h1>

--- a/mirage/factories/day.js
+++ b/mirage/factories/day.js
@@ -1,6 +1,0 @@
-import Mirage from 'ember-cli-mirage';
-// import moment from 'moment';
-
-export default Mirage.Factory.extend({
-  // date: (i) => moment().subtract(i, 'days').format('YYYY-MM-DD')
-});

--- a/mirage/factories/list.js
+++ b/mirage/factories/list.js
@@ -1,0 +1,9 @@
+import { Factory, trait } from 'ember-cli-mirage';
+import moment from 'moment';
+
+export default Factory.extend({
+  day: trait({
+    listType: 'day',
+    name: moment().format('YYYY-MM-DD'),
+  }),
+});

--- a/tests/acceptance/new-task-modal-test.js
+++ b/tests/acceptance/new-task-modal-test.js
@@ -9,7 +9,6 @@ module('Acceptance | New Task modal', function (hooks) {
   hooks.beforeEach(() => authenticateSession());
 
   test('adding a new task', async function (assert) {
-    this.server.logging = true;
     assert.expect(4);
 
     let list = this.server.create('list', {


### PR DESCRIPTION
This should improve the "remove a task" experience on mobile, at least for iOS Safari, where it defaults to putting Shift on when you remove all the text from a description, so you would have to manually turn off Shift before submitting.