### PR TITLE
Update Mirage imports to eliminate deprecations

### DIFF
--- a/mirage/factories/list.js
+++ b/mirage/factories/list.js
@@ -1,4 +1,4 @@
-import { Factory, trait } from 'ember-cli-mirage';
+import { Factory, trait } from 'miragejs';
 import moment from 'moment';
 
 export default Factory.extend({

--- a/mirage/factories/task.js
+++ b/mirage/factories/task.js
@@ -1,6 +1,6 @@
-import Mirage from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 
-export default Mirage.Factory.extend({
+export default Factory.extend({
   done: false,
   description: (i) => `Task ${i}`,
 });

--- a/mirage/models/day.js
+++ b/mirage/models/day.js
@@ -1,4 +1,4 @@
-import { Model, hasMany } from 'ember-cli-mirage';
+import { Model, hasMany } from 'miragejs';
 
 export default Model.extend({
   tasks: hasMany(),

--- a/mirage/models/task.js
+++ b/mirage/models/task.js
@@ -1,4 +1,4 @@
-import { Model, belongsTo } from 'ember-cli-mirage';
+import { Model, belongsTo } from 'miragejs';
 
 export default Model.extend({
   list: belongsTo(),

--- a/mirage/serializers/application.js
+++ b/mirage/serializers/application.js
@@ -1,3 +1,3 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import { JSONAPISerializer } from 'miragejs';
 
 export default JSONAPISerializer.extend({});

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "glob": "^7.2.0",
     "http-proxy": "^1.18.1",
     "loader.js": "^4.7.0",
+    "miragejs": "^0.1.43",
     "morgan": "^1.10.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.5.1",


### PR DESCRIPTION
Add an explicit `miragejs` dependency and update most Mirage-related imports to come from this package instead of `ember-cli-mirage`. This eliminates deprecation warnings.