### PR TITLE
Disable Mirage logging in CI

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -35,6 +35,8 @@ module.exports = function (environment) {
       simplifiedAutoLink: true,
       strikethrough: true,
     },
+
+    mirageLogging: typeof process.env.MIRAGE_LOGGING !== 'undefined' ? !!process.env.MIRAGE_LOGGING : false,
   };
 
   if (environment === 'development') {
@@ -44,8 +46,9 @@ module.exports = function (environment) {
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
     ENV['ember-cli-mirage'] = {
-      enabled: !!process.env['MIRAGE_ENABLED'],
+      enabled: !!process.env.MIRAGE_ENABLED,
     };
+    ENV.mirageLogging = typeof process.env.MIRAGE_LOGGING !== 'undefined' ? !!process.env.MIRAGE_LOGGING : true;
   }
 
   if (environment === 'test') {
@@ -58,6 +61,12 @@ module.exports = function (environment) {
 
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
+
+    if (typeof process.env.MIRAGE_LOGGING !== 'undefined') {
+      ENV.mirageLogging = !!process.env.MIRAGE_LOGGING;
+    } else {
+      ENV.mirageLogging = process.env.CI ? false : true;
+    }
   }
 
   if (environment === 'production') {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -1,5 +1,6 @@
 import { discoverEmberDataModels } from 'ember-cli-mirage';
 import { createServer } from 'miragejs';
+import config from 'ember-todo/config/environment';
 
 export default function (config) {
   let finalConfig = {
@@ -14,7 +15,7 @@ export default function (config) {
 function routes() {
   this.passthrough('/write-coverage');
 
-  this.logging = true;
+  this.logging = config.mirageLogging;
 
   this.namespace = '/api';
   this.post('/oauth/token', function () {


### PR DESCRIPTION
Also, allow it to be toggled (for any environment) with `MIRAGE_LOGGING` environment variable. Closes #41.