### PR TITLE
Stop list of tasks flickering when the list includes overdue tasks

### DIFF
--- a/app/components/overdue-task-list.hbs
+++ b/app/components/overdue-task-list.hbs
@@ -17,7 +17,7 @@
         data-test-task
       >
         <:after>
-          <p class="due-date">Due {{task.list.name}}</p>
+          <p class="due-date">Due {{task.dueDate}}</p>
         </:after>
       </SingleTask>
     {{/each}}

--- a/app/components/task-form.js
+++ b/app/components/task-form.js
@@ -6,10 +6,7 @@ import { isEmpty } from '@ember/utils';
 
 function taskDate(task) {
   if (!task) return null;
-  if (!task.list) return null;
-  if (task.list.listType !== 'day') return null;
-
-  return task.list.name;
+  return task.dueDate;
 }
 
 export default class TaskForm extends Component {

--- a/app/components/task-list.js
+++ b/app/components/task-list.js
@@ -8,8 +8,8 @@ import TaskListHeaderComponent from 'ember-todo/components/task-list/header';
 
 function taskSort(a, b) {
   // unfinished tasks display above finished or pending
-  if (a.done === true && b.done === false) return -1;
-  if (a.done === false && b.done === true) return 1;
+  if (a.done === true && b.done === false) return 1;
+  if (a.done === false && b.done === true) return -1;
 
   // unfinished & finished tasks display above pending
   if (a.isNew === false && b.isNew === true) return -1;
@@ -35,7 +35,7 @@ export default class TaskList extends Component {
   }
 
   get sortedTasks() {
-    return Array.from(this.args.list.tasks).sort((a, b) => taskSort(a, b));
+    return Array.from(this.args.list.tasks).toSorted((a, b) => taskSort(a, b));
   }
 
   get unfinishedTasks() {

--- a/app/models/task.js
+++ b/app/models/task.js
@@ -1,10 +1,11 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class Task extends Model {
-  @belongsTo('list', { async: false, inverse: 'tasks' }) list;
+  @belongsTo('list', { async: true, inverse: 'tasks' }) list;
 
   @attr('string') description;
   @attr('boolean') done;
+  @attr('string') dueDate;
   @attr('string') notes;
 
   get plaintextDescription() {

--- a/app/serializers/task.js
+++ b/app/serializers/task.js
@@ -1,0 +1,7 @@
+import ApplicationSerializer from './application';
+
+export default class TaskSerializer extends ApplicationSerializer {
+  attrs = {
+    dueDate: { serialize: false },
+  };
+}

--- a/app/services/poller.js
+++ b/app/services/poller.js
@@ -66,7 +66,6 @@ export default class PollerService extends Service {
 
   async loadOverdueTasks() {
     this.overdueTasks = await this.store.query('task', {
-      include: 'list',
       filter: { overdue: true },
       sort: 'due-date,plaintext-description',
     });

--- a/mirage/factories/task.js
+++ b/mirage/factories/task.js
@@ -13,7 +13,10 @@ export default Factory.extend({
         list = server.create('list', 'today');
       }
 
-      task.update({ list });
+      task.update({
+        list,
+        dueDate: list.name,
+      });
     },
   }),
 });

--- a/tests/acceptance/days-test.js
+++ b/tests/acceptance/days-test.js
@@ -105,6 +105,7 @@ module('Acceptance | Days', function (hooks) {
       name: '2023-01-01',
     });
     this.server.create('task', {
+      dueDate: '2023-01-01',
       list: oldList,
     });
 

--- a/tests/acceptance/tasks-test.js
+++ b/tests/acceptance/tasks-test.js
@@ -56,6 +56,7 @@ module('Acceptance | Tasks', function (hooks) {
     let list = this.server.create('list', 'today');
     this.server.create('task', {
       description: 'initial description',
+      dueDate: list.name,
       list,
     });
 
@@ -76,6 +77,7 @@ module('Acceptance | Tasks', function (hooks) {
     let list = this.server.create('list', 'today');
     let task = this.server.create('task', {
       description: 'initial description',
+      dueDate: list.name,
       list,
     });
 


### PR DESCRIPTION
Including the `list` relationship in the request for overdue tasks was causing the list of tasks for days with overdue tasks to flicker (since the data was driven by `list.tasks`, which was changing with the loading of overdue tasks). To get around that, the server now includes a read-only `due-date` attribute on a Task that we can use to pull the date, instead of accessing it from the list.