### PR TITLE
Stop polling when dragging a task (and restart after it's dropped/cancelled)

### DIFF
--- a/app/components/task-list.hbs
+++ b/app/components/task-list.hbs
@@ -13,7 +13,7 @@
         @task={{task}}
         @editingStart={{@editingStart}}
         @editingEnd={{@editingEnd}}
-        {{draggable-task task}}
+        {{draggable-task task onDragStart=@editingStart onDragEnd=@editingEnd}}
         data-test-task
       />
     {{/each}}

--- a/app/modifiers/draggable-task.js
+++ b/app/modifiers/draggable-task.js
@@ -10,10 +10,11 @@ export default modifier(function draggableTask(element, [task], { onDragStart, o
     dragging = true;
     onDragStart?.(task);
   };
-  let dragEndHandler = function (event) {
+  let dragEndHandler = function (/* event */) {
     dragging = false;
     onDragEnd?.(task);
-  }
+  };
+
   element.addEventListener('dragstart', dragStartHandler);
   element.addEventListener('dragend', dragEndHandler);
 

--- a/app/modifiers/draggable-task.js
+++ b/app/modifiers/draggable-task.js
@@ -1,15 +1,29 @@
 import { modifier } from 'ember-modifier';
 
-export default modifier(function draggableTask(element, [task]) {
+export default modifier(function draggableTask(element, [task], { onDragStart, onDragEnd }) {
   element.draggable = 'true';
+
+  let dragging = false;
 
   let dragStartHandler = function (event) {
     event.dataTransfer.setData('text/data', task.id);
+    dragging = true;
+    onDragStart?.(task);
   };
+  let dragEndHandler = function (event) {
+    dragging = false;
+    onDragEnd?.(task);
+  }
   element.addEventListener('dragstart', dragStartHandler);
+  element.addEventListener('dragend', dragEndHandler);
 
   return () => {
     element.draggable = null;
     element.removeEventListener('dragstart', dragStartHandler);
+    element.removeEventListener('dragend', dragEndHandler);
+
+    // the element gets torn down as a result of the "drop" action;
+    // if this happens, we still want to fire the 'onDragEnd' action.
+    if (dragging) onDragEnd?.(task);
   };
 });


### PR DESCRIPTION
Fixes #91