### PR TITLE
Don't restart polling after a drag-and-drop operation until the save has completed

### DIFF
--- a/app/components/task-list.js
+++ b/app/components/task-list.js
@@ -79,9 +79,10 @@ export default class TaskList extends Component {
     }
   }
 
-  moveTaskToList(task) {
+  async moveTaskToList(task) {
     task.list = this.args.list;
-    task.save();
+    await task.save();
+    this.args.editingEnd?.();
   }
 
   @action

--- a/app/modifiers/draggable-task.js
+++ b/app/modifiers/draggable-task.js
@@ -3,15 +3,11 @@ import { modifier } from 'ember-modifier';
 export default modifier(function draggableTask(element, [task], { onDragStart, onDragEnd }) {
   element.draggable = 'true';
 
-  let dragging = false;
-
   let dragStartHandler = function (event) {
     event.dataTransfer.setData('text/data', task.id);
-    dragging = true;
     onDragStart?.(task);
   };
   let dragEndHandler = function (/* event */) {
-    dragging = false;
     onDragEnd?.(task);
   };
 
@@ -22,9 +18,5 @@ export default modifier(function draggableTask(element, [task], { onDragStart, o
     element.draggable = null;
     element.removeEventListener('dragstart', dragStartHandler);
     element.removeEventListener('dragend', dragEndHandler);
-
-    // the element gets torn down as a result of the "drop" action;
-    // if this happens, we still want to fire the 'onDragEnd' action.
-    if (dragging) onDragEnd?.(task);
   };
 });


### PR DESCRIPTION
Fixes #97 (hopefully).